### PR TITLE
Added missing option to use 'Normal AST Parse Result' instead of Prot…

### DIFF
--- a/lib/api-mock.js
+++ b/lib/api-mock.js
@@ -54,7 +54,9 @@ ApiMock = (function() {
       throw e;
     }
     ast_json = "";
-    return protagonist.parse(data, function(error, result) {
+    return protagonist.parse(data, {
+      type: 'ast'
+    }, function(error, result) {
       var _ref, _ref1;
       if (error != null) {
         throw error;

--- a/src/api-mock.coffee
+++ b/src/api-mock.coffee
@@ -40,7 +40,7 @@ class ApiMock
 
     # Get JSON representation of the blueprint file
     ast_json = ""
-    protagonist.parse data,  (error, result) =>
+    protagonist.parse data, { type: 'ast' },  (error, result) =>
       if error? then throw error
       ast_json = result.ast
 


### PR DESCRIPTION
…agonist's default 'Refract Parse Result'.